### PR TITLE
Add Google Calendar meal plan API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # familyhub-mealboard
+
+## Google Calendar dinner plans
+
+The application can fetch upcoming dinner plans from a shared Google Calendar.
+Events within a 7‑day window around today are returned by the `/api/meals`
+endpoint as a dictionary keyed by ISO date strings.
+
+### Setup
+1. **Create a Google service account** and download its JSON key.
+2. **Share the calendar** with the service account's e‑mail (read access is
+   enough).
+3. Set the following environment variables:
+
+   - `GOOGLE_APPLICATION_CREDENTIALS`: Path to the downloaded JSON key file.
+   - `FAMILYHUB_CALENDAR_ID`: ID of the shared calendar.
+   - Optional `FAMILYHUB_TZ`: Timezone name (defaults to `America/Chicago`).
+
+With these variables configured, the `/api/meals` route will return the
+meal plan as JSON and can be consumed by the frontend.

--- a/calendar_api.py
+++ b/calendar_api.py
@@ -1,0 +1,50 @@
+import os
+import datetime
+import pytz
+from dateutil.relativedelta import relativedelta
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
+SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
+CAL_ID = os.getenv('FAMILYHUB_CALENDAR_ID')
+
+def get_meals():
+    """Fetch dinner plans from a shared Google Calendar.
+
+    Returns a dictionary mapping ISO-formatted dates to lists of meal names.
+    If required environment variables are missing, an error dictionary is
+    returned instead.
+    """
+    creds_path = os.getenv('GOOGLE_APPLICATION_CREDENTIALS')
+    if not creds_path or not os.path.exists(creds_path):
+        return {"error": "Missing GOOGLE_APPLICATION_CREDENTIALS or file not found"}
+    if not CAL_ID:
+        return {"error": "Missing FAMILYHUB_CALENDAR_ID"}
+
+    creds = service_account.Credentials.from_service_account_file(creds_path, scopes=SCOPES)
+    svc = build('calendar', 'v3', credentials=creds, cache_discovery=False)
+
+    tz = pytz.timezone(os.getenv('FAMILYHUB_TZ', 'America/Chicago'))
+    now = datetime.datetime.now(tz).replace(hour=0, minute=0, second=0, microsecond=0)
+    start_dt = now - relativedelta(days=7)
+    end_dt = now + relativedelta(days=7, hours=23, minutes=59)
+
+    res = svc.events().list(
+        calendarId=CAL_ID,
+        timeMin=start_dt.isoformat(),
+        timeMax=end_dt.isoformat(),
+        singleEvents=True,
+        orderBy='startTime'
+    ).execute()
+
+    items = res.get('items', [])
+    out = {}
+    for i in range(-7, 8):
+        d = (now + relativedelta(days=i)).date().isoformat()
+        out[d] = []
+
+    for e in items:
+        start = e['start'].get('date') or e['start'].get('dateTime', '')[:10]
+        if start in out:
+            out[start].append(e.get('summary', 'Dinner'))
+    return out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,8 @@ dependencies = [
     "flask-login>=0.6.3",
     "oauthlib>=3.3.1",
     "pyjwt>=2.10.1",
+    "google-api-python-client>=2.154.0",
+    "google-auth>=2.29.0",
+    "python-dateutil>=2.9.0.post0",
+    "pytz>=2024.1",
 ]

--- a/routes.py
+++ b/routes.py
@@ -1,9 +1,10 @@
-from flask import session, render_template, request, redirect, url_for, flash
+from flask import session, render_template, request, redirect, url_for, flash, jsonify
 from datetime import datetime, date
 from app import app, db
 from replit_auth import require_login, require_admin, make_replit_blueprint
 from flask_login import current_user
 from models import Chore, MealPlan, Notification, User
+from calendar_api import get_meals
 
 app.register_blueprint(make_replit_blueprint(), url_prefix="/auth")
 
@@ -11,6 +12,12 @@ app.register_blueprint(make_replit_blueprint(), url_prefix="/auth")
 @app.before_request
 def make_session_permanent():
     session.permanent = True
+
+
+@app.route('/api/meals')
+def api_meals():
+    """Return dinner plans from the shared Google Calendar."""
+    return jsonify(get_meals())
 
 # Public routes
 @app.route('/')


### PR DESCRIPTION
## Summary
- fetch dinner plans from a shared Google Calendar via new helper and `/api/meals` endpoint
- document required environment variables for calendar access
- add Google API dependencies

## Testing
- `pytest -q`
- `python -m py_compile calendar_api.py routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68960bfc79408330b20868f925a7a32c