### PR TITLE
Add weekday recurrence scheduling for chores

### DIFF
--- a/services/chores_service.py
+++ b/services/chores_service.py
@@ -181,6 +181,8 @@ def create_chore(
     priority: str = "low",
     notes: Optional[str] = None,
     points: int = 1,
+    recurrence: Optional[list[str]] = None,
+    due_rfc3339: Optional[str] = None,
 ) -> ChoreDTO:
     """Creates a new chore in the backend and stores metadata locally."""
     if CHORES_BACKEND != "google":
@@ -191,9 +193,13 @@ def create_chore(
     body: dict = {"title": title}
     if notes:
         body["notes"] = notes.strip()
-    if due_date:
+    if due_rfc3339:
+        body["due"] = due_rfc3339
+    elif due_date:
         # Google Tasks API requires due date in RFC 3339 format.
         body["due"] = due_date.isoformat() + "T00:00:00.000Z"
+    if recurrence:
+        body["recurrence"] = recurrence
 
     # Create the task and log the result
     task = svc.tasks().insert(tasklist=task_list_id, body=body).execute()

--- a/services/schedule_utils.py
+++ b/services/schedule_utils.py
@@ -1,0 +1,28 @@
+from datetime import date, datetime, timedelta
+import zoneinfo
+
+WK = {"Monday":0, "Tuesday":1, "Wednesday":2, "Thursday":3, "Friday":4, "Saturday":5, "Sunday":6}
+BY = {0:"MO",1:"TU",2:"WE",3:"TH",4:"FR",5:"SA",6:"SU"}
+
+def next_on_or_after(start: date, target_wd: int) -> date:
+    """Return the date that is start if start.weekday()==target_wd else next future date with that weekday."""
+    delta = (target_wd - start.weekday()) % 7
+    return start + timedelta(days=delta)
+
+
+def next_in_set_on_or_after(start: date, wdays: set[int]) -> date:
+    for i in range(7):
+        d = start + timedelta(days=i)
+        if d.weekday() in wdays:
+            return d
+    return start  # fallback, though loop always returns within 7 days
+
+
+def to_utc_midnight_rfc3339(d: date, tz_name: str | None = None) -> str:
+    """Return RFC3339 UTC midnight string for the given local date."""
+    tz = zoneinfo.ZoneInfo(tz_name) if tz_name else datetime.now().astimezone().tzinfo
+    # Local midnight
+    local_midnight = datetime(d.year, d.month, d.day, 0, 0, 0, tzinfo=tz)
+    # Convert to UTC
+    utc_dt = local_midnight.astimezone(zoneinfo.ZoneInfo("UTC"))
+    return utc_dt.strftime("%Y-%m-%dT%H:%M:%S.000Z")

--- a/templates/base.html
+++ b/templates/base.html
@@ -29,7 +29,7 @@
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link {% if _path.startswith('/rewards') %}active{% endif %}" href="{{ url_for('rewards.rewards_home') }}">
+                <a class="nav-link {% if _path.startswith('/rewards') %}active{% endif %}" href="{{ safe_url_for('rewards.rewards_home') }}">
                     <i class="fas fa-gift"></i>
                     <span>Rewards</span>
                 </a>

--- a/templates/create_chore.html
+++ b/templates/create_chore.html
@@ -43,10 +43,28 @@
       </select>
     </div>
 
-    <!-- Due date (tap-friendly) -->
-    <div class="mb-4">
-      <label for="due_date" class="form-label">Due Date</label>
-      <input type="date" name="due_date" id="due_date" class="form-control form-control-lg" required>
+    <!-- Day and recurrence -->
+    <div class="row g-2 mb-4">
+      <div class="col-md-6">
+        <label class="form-label">Day of the Week</label>
+        <select name="weekday" class="form-select">
+          <option value="">-- Select --</option>
+          {% for d in ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"] %}
+          <option value="{{ d }}">{{ d }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">Recurrence</label>
+        <select name="recurrence" class="form-select">
+          {% for opt in ["Once","Daily","School Days","Weekends","Once per week"] %}
+          <option value="{{ opt }}" {% if opt=="Once" %}selected{% endif %}>{{ opt }}</option>
+          {% endfor %}
+        </select>
+        <div class="form-text">
+          School Days = Mon–Fri, Weekends = Sat–Sun. “Once per week” uses the selected weekday.
+        </div>
+      </div>
     </div>
 
     <!-- Points -->


### PR DESCRIPTION
## Summary
- Add utilities for computing next eligible chore date and converting to UTC midnight
- Support recurrence RRULEs and due timestamps when creating tasks
- Extend chore creation route and template with weekday and recurrence selectors
- Use safe URL builder for Rewards link when blueprint disabled

## Testing
- `pytest`
- `pre-commit run --files services/schedule_utils.py services/chores_service.py routes.py templates/create_chore.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897c99ca8f883308323f2e399af6946