### PR TITLE
Add Raspberry Pi deployment scripts and systemd unit

### DIFF
--- a/README-setup.md
+++ b/README-setup.md
@@ -1,0 +1,40 @@
+# Raspberry Pi Setup
+
+## Quick start
+```bash
+cd /home/pi && git clone <YOUR_REPO_URL> familyhub
+cd familyhub
+sudo bash scripts/setup_pi.sh
+```
+
+## Re-run or upgrade
+```bash
+# safe to re-run anytime; handles existing service/files
+sudo bash scripts/setup_pi.sh
+```
+
+## Reconfigure environment or secrets
+```bash
+sudo bash scripts/configure_env.sh
+sudo systemctl restart familyhub
+```
+
+## Manual run
+```bash
+bash scripts/run_local.sh
+```
+
+## Acceptance tests
+```bash
+systemctl is-active familyhub
+journalctl -u familyhub -n 50
+sudo test -f /etc/default/familyhub
+sudo test -f /etc/familyhub/service_account.json
+```
+Ensure the app responds on HOST:PORT.
+
+## Troubleshooting
+- Service fails to start → `journalctl -u familyhub -e -f`
+- Wrong paths in unit → run setup again (migrates unit)
+- Python upgraded → setup auto-recreates venv
+- Dry run: `DRY_RUN=1 sudo -E bash scripts/setup_pi.sh`

--- a/scripts/configure_env.sh
+++ b/scripts/configure_env.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+APP_NAME=${APP_NAME:-familyhub}
+APP_USER=${APP_USER:-pi}
+APP_DIR=${APP_DIR:-/home/pi/familyhub}
+ENV_FILE=${ENV_FILE:-/etc/default/${APP_NAME}}
+SECRET_DIR=${SECRET_DIR:-/etc/${APP_NAME}}
+SECRET_PATH=${SECRET_PATH:-${SECRET_DIR}/service_account.json}
+
+log(){ echo "$1 $2"; }
+info(){ log "ℹ️" "$*"; }
+success(){ log "✅" "$*"; }
+warn(){ log "⚠️" "$*"; }
+
+[[ $EUID -eq 0 ]] || { echo "Must run as root"; exit 1; }
+
+mkdir -p "$SECRET_DIR"
+chmod 0750 "$SECRET_DIR"
+
+BACKED_UP_ENV=""
+backup_env(){
+  if [[ -f "$ENV_FILE" && -z "$BACKED_UP_ENV" ]]; then
+    BACKED_UP_ENV=1
+    local backup="${ENV_FILE}.bak-$(date +%Y%m%d-%H%M%S)"
+    cp "$ENV_FILE" "$backup"
+    info "Backup of env at $backup"
+  fi
+}
+
+merge_kv(){
+  local file="$1" key="$2" val="$3" tmp
+  backup_env
+  tmp=$(mktemp)
+  if [[ -f "$file" ]]; then
+    awk -v k="$key" -v v="$val" 'BEGIN{found=0}
+      $0~"^"k"=" {print k"="v; found=1; next}
+      {print}
+      END{if(!found) print k"="v}' "$file" > "$tmp"
+  else
+    printf '%s=%s\n' "$key" "$val" > "$tmp"
+  fi
+  install -m 0644 "$tmp" "$file"
+}
+
+command -v whiptail >/dev/null && HAVE_WHIPTAIL=1 || HAVE_WHIPTAIL=0
+
+ask(){
+  local prompt="$1" default="$2" val
+  if [[ $HAVE_WHIPTAIL -eq 1 ]]; then
+    val=$(whiptail --inputbox "$prompt" 8 60 "$default" 3>&1 1>&2 2>&3) || exit 1
+  else
+    read -rp "$prompt [$default]: " val
+    val=${val:-$default}
+  fi
+  echo "$val"
+}
+
+yesno(){
+  local prompt="$1" default="$2" ans
+  if [[ $HAVE_WHIPTAIL -eq 1 ]]; then
+    if [[ "$default" == "Y" ]]; then
+      whiptail --yesno "$prompt" 8 60 && return 0 || return 1
+    else
+      whiptail --yesno "$prompt" 8 60 && return 0 || return 1
+    fi
+  else
+    read -rp "$prompt [${default}/n]: " ans
+    ans=${ans:-$default}
+    [[ "$ans" =~ ^[Yy]$ ]]
+  fi
+}
+
+HOST=$(ask "Host to bind" "${HOST:-0.0.0.0}")
+PORT=$(ask "Port" "${PORT:-8000}")
+while ! [[ "$PORT" =~ ^[0-9]+$ && $PORT -ge 1 && $PORT -le 65535 ]]; do
+  warn "Port must be 1-65535"
+  PORT=$(ask "Port" "8000")
+done
+FAMILYHUB_HEALTH_ENABLED=$(ask "Enable health endpoint (true/false)" "${FAMILYHUB_HEALTH_ENABLED:-true}")
+FAMILYHUB_CALENDAR_ID=$(ask "Google Calendar ID (optional)" "${FAMILYHUB_CALENDAR_ID:-}")
+
+# Secret handling
+REPLACE_SECRET=1
+if [[ -f "$SECRET_PATH" ]]; then
+  if yesno "Service account exists. Replace?" "n"; then
+    REPLACE_SECRET=1
+  else
+    REPLACE_SECRET=0
+  fi
+fi
+
+if [[ $REPLACE_SECRET -eq 1 ]]; then
+  backup=""
+  if [[ -f "$SECRET_PATH" ]]; then
+    backup="${SECRET_PATH}.bak-$(date +%Y%m%d-%H%M%S)"
+    cp "$SECRET_PATH" "$backup"
+    info "Backup of old secret at $backup"
+  fi
+  if yesno "Provide path to JSON file? (No to paste)" "Y"; then
+    SRC=$(ask "Path to service account JSON" "")
+    install -m 0600 "$SRC" "$SECRET_PATH"
+  else
+    tmp=$(mktemp)
+    echo "Paste JSON, end with Ctrl-D:" >&2
+    cat > "$tmp"
+    install -m 0600 "$tmp" "$SECRET_PATH"
+    rm -f "$tmp"
+  fi
+fi
+chown root:root "$SECRET_PATH"
+chmod 0600 "$SECRET_PATH"
+
+merge_kv "$ENV_FILE" "HOST" "$HOST"
+merge_kv "$ENV_FILE" "PORT" "$PORT"
+merge_kv "$ENV_FILE" "FAMILYHUB_HEALTH_ENABLED" "$FAMILYHUB_HEALTH_ENABLED"
+if [[ -n "$FAMILYHUB_CALENDAR_ID" ]]; then
+  merge_kv "$ENV_FILE" "FAMILYHUB_CALENDAR_ID" "$FAMILYHUB_CALENDAR_ID"
+fi
+merge_kv "$ENV_FILE" "GOOGLE_APPLICATION_CREDENTIALS" "$SECRET_PATH"
+
+success "Updated $ENV_FILE"
+cat "$ENV_FILE"

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+APP_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+VENV_DIR="$APP_DIR/.venv"
+ENV_LOCAL="$APP_DIR/.env"
+ENV_SYSTEM="/etc/default/familyhub"
+
+ensure_venv(){
+  if [[ ! -x "$VENV_DIR/bin/python" ]]; then
+    python3 -m venv "$VENV_DIR"
+    "$VENV_DIR/bin/pip" install --upgrade pip wheel
+    if [[ -f "$APP_DIR/requirements.txt" ]]; then
+      "$VENV_DIR/bin/pip" install -r "$APP_DIR/requirements.txt"
+    fi
+  fi
+}
+
+ensure_venv
+
+ENV_USED=""
+if [[ -f "$ENV_LOCAL" ]]; then
+  set -a; source "$ENV_LOCAL"; set +a
+  ENV_USED="$ENV_LOCAL"
+else
+  if [[ -f "$ENV_SYSTEM" ]]; then
+    set -a; source "$ENV_SYSTEM"; set +a
+    ENV_USED="$ENV_SYSTEM"
+  fi
+fi
+
+if [[ -n "$ENV_USED" ]]; then
+  echo "Using env from $ENV_USED"
+else
+  echo "No env file found; running with current environment"
+fi
+
+exec "$VENV_DIR/bin/python" "$APP_DIR/main.py"

--- a/scripts/setup_pi.sh
+++ b/scripts/setup_pi.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+APP_NAME=${APP_NAME:-familyhub}
+APP_USER=${APP_USER:-pi}
+APP_DIR=${APP_DIR:-/home/pi/familyhub}
+VENV_DIR=${VENV_DIR:-$APP_DIR/.venv}
+ENV_FILE=${ENV_FILE:-/etc/default/$APP_NAME}
+SECRET_DIR=${SECRET_DIR:-/etc/$APP_NAME}
+SECRET_PATH=${SECRET_PATH:-$SECRET_DIR/service_account.json}
+LOCK_FILE=/var/lock/${APP_NAME}-setup.lock
+DRY_RUN=${DRY_RUN:-0}
+
+log(){ echo "$1 $2"; }
+info(){ log "ℹ️" "$*"; }
+success(){ log "✅" "$*"; }
+warn(){ log "⚠️" "$*"; }
+
+run(){
+  if [[ "$DRY_RUN" == 1 ]]; then
+    echo "DRY RUN: $*"
+  else
+    eval "$@"
+  fi
+}
+
+# acquire lock
+exec 9>"$LOCK_FILE"
+flock -n 9 || { echo "Another setup is running"; exit 1; }
+trap 'flock -u 9' EXIT
+
+# preflight
+[[ $EUID -eq 0 ]] || { echo "Run as root"; exit 1; }
+[[ $(ps -p 1 -o comm=) == systemd ]] || { echo "systemd required"; exit 1; }
+PY_VER=$(python3 -c 'import sys; print(".".join(map(str,sys.version_info[:2])))')
+if [[ "$(printf '%s\n3.11\n' "$PY_VER" | sort -V | head -n1)" != "3.11" ]]; then
+echo "Python >=3.11 required"; exit 1
+fi
+
+info "Installing dependencies"
+run apt-get update -y
+run apt-get install -y python3-venv python3-pip pkg-config libsystemd-dev whiptail
+
+ensure_venv(){
+  local recreate=0
+  if [[ ! -x "$VENV_DIR/bin/python" ]]; then
+    recreate=1
+  else
+    local vver=$("$VENV_DIR/bin/python" -c 'import sys; print(".".join(map(str,sys.version_info[:2])))')
+    [[ "$vver" != "$PY_VER" ]] && recreate=1
+  fi
+  if [[ $recreate -eq 1 ]]; then
+    info "Creating virtualenv"
+    run rm -rf "$VENV_DIR"
+    run python3 -m venv "$VENV_DIR"
+  fi
+  run "$VENV_DIR/bin/pip" install --upgrade pip wheel
+  if [[ -f "$APP_DIR/requirements.txt" ]]; then
+    run "$VENV_DIR/bin/pip" install -r "$APP_DIR/requirements.txt"
+  fi
+}
+ensure_venv
+
+ensure_kv(){
+  local file="$1" key="$2" val="$3" tmp
+  if grep -q "^$2=" "$file" 2>/dev/null; then
+    return
+  fi
+  tmp=$(mktemp)
+  if [[ -f "$file" ]]; then
+    cat "$file" > "$tmp"
+  fi
+  printf '%s=%s\n' "$key" "$val" >> "$tmp"
+  if [[ "$DRY_RUN" == 1 ]]; then
+    echo "DRY RUN: update $file with $key=$val"
+    rm -f "$tmp"
+  else
+    install -m 0644 "$tmp" "$file"
+  fi
+}
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  info "Environment file missing; running configure_env.sh"
+  if [[ "$DRY_RUN" == 1 ]]; then
+    echo "DRY RUN: scripts/configure_env.sh"
+  else
+    scripts/configure_env.sh
+  fi
+else
+  ensure_kv "$ENV_FILE" "GOOGLE_APPLICATION_CREDENTIALS" "$SECRET_PATH"
+  chmod 0644 "$ENV_FILE"
+fi
+
+if [[ ! -f "$SECRET_PATH" ]]; then
+  info "Service account missing; running configure_env.sh"
+  if [[ "$DRY_RUN" == 1 ]]; then
+    echo "DRY RUN: scripts/configure_env.sh"
+  else
+    scripts/configure_env.sh
+  fi
+else
+  chmod 0600 "$SECRET_PATH"
+  chown root:root "$SECRET_PATH"
+fi
+mkdir -p "$SECRET_DIR"
+chmod 0750 "$SECRET_DIR"
+chown root:root "$SECRET_DIR"
+
+install_service(){
+  local unit="/etc/systemd/system/${APP_NAME}.service" tmp backup
+  if systemctl is-active --quiet ${APP_NAME}.service; then
+    run systemctl stop ${APP_NAME}.service || true
+  fi
+  tmp=$(mktemp)
+  cat > "$tmp" <<SERV
+[Unit]
+Description=FamilyHub Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# To enable sdnotify/watchdog later, switch to:
+# Type=notify
+# WatchdogSec=30s
+User=${APP_USER}
+WorkingDirectory=${APP_DIR}
+EnvironmentFile=${ENV_FILE}
+ExecStart=${VENV_DIR}/bin/python ${APP_DIR}/main.py
+Restart=on-failure
+RestartSec=2
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+SERV
+  if [[ -f "$unit" ]]; then
+    backup="${unit}.bak-$(date +%Y%m%d-%H%M%S)"
+    run cp "$unit" "$backup"
+  fi
+  run install -m 0644 "$tmp" "$unit"
+  rm -f "$tmp"
+  run systemctl daemon-reload
+  run systemctl enable --now ${APP_NAME}.service
+}
+install_service
+
+if [[ "$DRY_RUN" != 1 ]]; then
+  sleep 1
+  if ! systemctl is-active --quiet ${APP_NAME}.service; then
+    warn "Service failed to start; last logs:"; journalctl -u ${APP_NAME}.service -n 50 || true; exit 1
+  fi
+  success "Service ${APP_NAME}.service is active"
+fi
+
+success "Setup complete"
+info "Re-run this script anytime: sudo bash scripts/setup_pi.sh"

--- a/systemd/familyhub.service
+++ b/systemd/familyhub.service
@@ -1,16 +1,19 @@
 [Unit]
 Description=FamilyHub Service
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
-Type=notify
-WatchdogSec=30
-Restart=on-failure
-RestartSec=2
+Type=simple
+# To enable sdnotify/watchdog later, switch to:
+# Type=notify
+# WatchdogSec=30s
 User=pi
 WorkingDirectory=/home/pi/familyhub
 EnvironmentFile=/etc/default/familyhub
-ExecStart=/usr/bin/python3 /home/pi/familyhub/main.py
+ExecStart=/home/pi/familyhub/.venv/bin/python /home/pi/familyhub/main.py
+Restart=on-failure
+RestartSec=2
 StandardOutput=journal
 StandardError=journal
 


### PR DESCRIPTION
## Summary
- add idempotent `scripts/setup_pi.sh` with venv, env merging, secret handling and systemd install
- add `scripts/configure_env.sh` wizard for env and secrets
- add `scripts/run_local.sh` helper and document usage in `README-setup.md`
- update systemd unit to use venv and journal logging

## Testing
- `pytest` *(fails: ImportError: cannot import name 'to_rrule')*


------
https://chatgpt.com/codex/tasks/task_e_68991bb5216483308b2fce0a2ef42c0f